### PR TITLE
Add _run_loop callback function

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -41,6 +41,8 @@
 #include "core/os/memory.h"
 #include "core/variant/variant.h"
 #include "core/version.h"
+#include "main/main.h"
+#include "servers/display_server.h"
 
 class CallableCustomExtension : public CallableCustom {
 	void *userdata;
@@ -1209,6 +1211,15 @@ static void gdextension_ref_set_object(GDExtensionRefPtr p_ref, GDExtensionObjec
 	ref->reference_ptr(o);
 }
 
+static void gdextension_displayserver_set_runloop(void (*runloop) (void)) {
+	auto display_server = DisplayServer::get_singleton();
+	display_server->set_runloop(runloop);
+}
+
+static void gdextension_main_iteration() {
+	Main::iteration();
+}
+
 #ifndef DISABLE_DEPRECATED
 static GDExtensionScriptInstancePtr gdextension_script_instance_create(const GDExtensionScriptInstanceInfo *p_info, GDExtensionScriptInstanceDataPtr p_instance_data) {
 	GDExtensionScriptInstanceInfo2 *info_2 = memnew(GDExtensionScriptInstanceInfo2);
@@ -1516,6 +1527,8 @@ void gdextension_setup_interface() {
 	REGISTER_INTERFACE_FUNC(classdb_get_class_tag);
 	REGISTER_INTERFACE_FUNC(editor_add_plugin);
 	REGISTER_INTERFACE_FUNC(editor_remove_plugin);
+	REGISTER_INTERFACE_FUNC(displayserver_set_runloop);
+	REGISTER_INTERFACE_FUNC(main_iteration);
 }
 
 #undef REGISTER_INTERFACE_FUNCTION

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -926,7 +926,11 @@ void OS_LinuxBSD::run() {
 	//uint64_t frame=0;
 
 	while (true) {
-		DisplayServer::get_singleton()->process_events(); // get rid of pending events
+		auto display_server = DisplayServer::get_singleton();
+		auto runloop = display_server->get_runloop();
+		runloop();
+		
+		display_server->process_events(); // get rid of pending events
 #ifdef JOYDEV_ENABLED
 		joypad->process_joypads();
 #endif

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -38,15 +38,29 @@
 
 class Texture2D;
 
+typedef void (*runloop_function_t) (void);
+
+static void __default_run_loop() {}
+
 class DisplayServer : public Object {
 	GDCLASS(DisplayServer, Object)
 
 	static DisplayServer *singleton;
 	static bool hidpi_allowed;
 
+	runloop_function_t _run_loop = &__default_run_loop;
+
 public:
 	_FORCE_INLINE_ static DisplayServer *get_singleton() {
 		return singleton;
+	}
+
+	_FORCE_INLINE_ runloop_function_t get_runloop() const {
+		return _run_loop;
+	}
+
+	_FORCE_INLINE_ void set_runloop(runloop_function_t runloop) {
+		_run_loop = runloop;
 	}
 
 	enum WindowMode {


### PR DESCRIPTION
Installed by extensions that need to service a runloop, which is needed for testing and Swift main actor concurrency to work on Linux systems.

Also added extension function displayserver_set_runloop and main_iteration. The latter provides a way to give time to Godot's main loop while the runloop has control.