### PR TITLE
Extension searching tweaks

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -144,6 +144,10 @@ void OS::alert(const String &p_alert, const String &p_title) {
 	fprintf(stderr, "%s: %s\n", p_title.utf8().get_data(), p_alert.utf8().get_data());
 }
 
+void OS::set_dynamic_library_search_path(const String &p_path) { 
+	_library_search_path = p_path; 
+}
+
 void OS::set_low_processor_usage_mode(bool p_enabled) {
 	low_processor_usage_mode = p_enabled;
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -56,6 +56,7 @@ class OS {
 	bool _verbose_stdout = false;
 	bool _debug_stdout = false;
 	String _local_clipboard;
+	String _library_search_path;
 	// Assume success by default, all failure cases need to set EXIT_FAILURE explicitly.
 	int _exit_code = EXIT_SUCCESS;
 	bool _allow_hidpi = false;
@@ -164,7 +165,10 @@ public:
 	virtual Error open_dynamic_library(const String &p_path, void *&p_library_handle, GDExtensionData *p_data = nullptr) { return ERR_UNAVAILABLE; }
 	virtual Error close_dynamic_library(void *p_library_handle) { return ERR_UNAVAILABLE; }
 	virtual Error get_dynamic_library_symbol_handle(void *p_library_handle, const String &p_name, void *&p_symbol_handle, bool p_optional = false) { return ERR_UNAVAILABLE; }
-
+	
+	String get_dynamic_library_search_path() { return _library_search_path; }
+	void set_dynamic_library_search_path(const String &p_path);
+	
 	virtual void set_low_processor_usage_mode(bool p_enabled);
 	virtual bool is_in_low_processor_usage_mode() const;
 	virtual void set_low_processor_usage_mode_sleep_usec(int p_usec);

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -59,6 +59,12 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie) {
 		args.push_back(resource_path.replace(" ", "%20"));
 	}
 
+	String library_search_path = OS::get_singleton()->get_dynamic_library_search_path();
+	if (!library_search_path.is_empty()) {
+		args.push_back("--library-path");
+		args.push_back(library_search_path);
+	}
+	
 	const String debug_uri = EditorDebuggerNode::get_singleton()->get_server_uri();
 	if (debug_uri.size()) {
 		args.push_back("--remote-debug");

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1543,7 +1543,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				String p = N->get();
 				OS::get_singleton()->set_dynamic_library_search_path(p);
 				N = N->next();
-				OS::get_singleton()->print("Library path set to: \"%s\"\n", p.utf8().get_data());
 			}
 		} else if (arg == "-u" || arg == "--upwards") { // scan folders upwards
 			upwards = true;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -541,6 +541,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("--quit-after <int>", "Quit after the given number of iterations. Set to 0 to disable.\n");
 	print_help_option("-l, --language <locale>", "Use a specific locale (<locale> being a two-letter code).\n");
 	print_help_option("--path <directory>", "Path to a project (<directory> must contain a \"project.godot\" file).\n");
+	print_help_option("--library-path <directory>", "Additional path to search for extension libraries.\n");
 	print_help_option("-u, --upwards", "Scan folders upwards for project.godot file.\n");
 	print_help_option("--main-pack <file>", "Path to a pack (.pck) file to load.\n");
 	print_help_option("--render-thread <mode>", "Render thread mode (\"unsafe\", \"safe\", \"separate\").\n");
@@ -1536,6 +1537,13 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			} else {
 				OS::get_singleton()->print("Missing relative or absolute path, aborting.\n");
 				goto error;
+			}
+		} else if (arg == "--library-path") { // set path to use to look for libraries
+			if (N) {
+				String p = N->get();
+				OS::get_singleton()->set_dynamic_library_search_path(p);
+				N = N->next();
+				OS::get_singleton()->print("Library path set to: \"%s\"\n", p.utf8().get_data());
 			}
 		} else if (arg == "-u" || arg == "--upwards") { // scan folders upwards
 			upwards = true;

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -237,6 +237,15 @@ Error OS_MacOS::open_dynamic_library(const String &p_path, void *&p_library_hand
 		path = get_framework_executable(get_executable_path().get_base_dir().path_join("../Frameworks").path_join(p_path.get_file()));
 	}
 
+#ifdef TOOLS_ENABLED
+	if (!FileAccess::exists(path)) {
+		if (has_environment("GODOT_EDITOR_LIBRARY_PATH")) {
+			// Load .dylib or framework from a custom location supplied by the environment.
+			path = get_framework_executable(get_environment("GODOT_EDITOR_LIBRARY_PATH").path_join(p_path.get_file()));
+		}
+	}
+#endif
+
 	ERR_FAIL_COND_V(!FileAccess::exists(path), ERR_FILE_NOT_FOUND);
 
 	p_library_handle = dlopen(path.utf8().get_data(), RTLD_NOW);

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -258,6 +258,13 @@ Error OS_MacOS::open_dynamic_library(const String &p_path, void *&p_library_hand
 		// Load .dylib or framework from PackageFrameworks (eg when running from the Xcode Build Folder).
 		path = get_framework_executable(get_executable_path().get_base_dir().path_join("PackageFrameworks").path_join(p_path.get_file()));
 	}
+
+	if (!FileAccess::exists(path)) {
+		// Load .dylib or framework from a custom location supplied on the command line.
+		path = get_framework_executable(OS::get_singleton()->get_dynamic_library_search_path().path_join(p_path.get_file()));
+		OS::get_singleton()->print("trying %s\n", path.utf8().get_data());
+	}
+
 #ifdef TOOLS_ENABLED
 	if (!FileAccess::exists(path)) {
 		if (has_environment("GODOT_EDITOR_LIBRARY_PATH")) {

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -262,7 +262,6 @@ Error OS_MacOS::open_dynamic_library(const String &p_path, void *&p_library_hand
 	if (!FileAccess::exists(path)) {
 		// Load .dylib or framework from a custom location supplied on the command line.
 		path = get_framework_executable(OS::get_singleton()->get_dynamic_library_search_path().path_join(p_path.get_file()));
-		OS::get_singleton()->print("trying %s\n", path.utf8().get_data());
 	}
 
 #ifdef TOOLS_ENABLED

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -220,6 +220,23 @@ _FORCE_INLINE_ String OS_MacOS::get_framework_executable(const String &p_path) {
 		return p_path.path_join(p_path.get_file().get_basename());
 	}
 
+	// If we've got no extension, try a couple
+	// of common patterns: lib<name>.dylib and <name>.framework.
+	if (p_path.get_extension().is_empty()) {
+		// Try adding .dylib extension.
+		String dylib_path = p_path.get_base_dir().path_join("lib" + p_path.get_file().get_basename() + ".dylib");
+		String expanded_dylib_path = get_framework_executable(dylib_path);
+		if (da->file_exists(expanded_dylib_path)) {
+			return expanded_dylib_path;
+		}
+		// Try adding .framework extension.
+		String framework_path = p_path + ".framework";
+		String expanded_framework_path = get_framework_executable(framework_path);
+		if (da->file_exists(expanded_framework_path)) {
+			return expanded_framework_path;
+		}
+	}
+
 	// Not a framework, try loading as .dylib.
 	return p_path;
 }

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -250,10 +250,14 @@ Error OS_MacOS::open_dynamic_library(const String &p_path, void *&p_library_hand
 	}
 
 	if (!FileAccess::exists(path)) {
-		// Load .dylib or framework from a standard macOS location.
+		// Load .dylib or framework from Frameworks (eg when running from an app bundle)
 		path = get_framework_executable(get_executable_path().get_base_dir().path_join("../Frameworks").path_join(p_path.get_file()));
 	}
 
+	if (!FileAccess::exists(path)) {
+		// Load .dylib or framework from PackageFrameworks (eg when running from the Xcode Build Folder).
+		path = get_framework_executable(get_executable_path().get_base_dir().path_join("PackageFrameworks").path_join(p_path.get_file()));
+	}
 #ifdef TOOLS_ENABLED
 	if (!FileAccess::exists(path)) {
 		if (has_environment("GODOT_EDITOR_LIBRARY_PATH")) {


### PR DESCRIPTION
Some tweaks aimed at making it a little easier to pick up the built framework/dylib for swift extensions.

- added an environment variable which can contain an additional directory path to search for libraries
- added a `--library-path` command line option which can contain an additional directory path to search for libraries
- enhanced the macOS library loading code to accept a name Foo and automatically search for `libFoo.dylib` and `Foo.framework`
- enhanced the macOS library loading code to also look in `PackageFrameworks/`. Xcode will build frameworks for Package dependencies into this folder

Some of these changes are useful in the context of SwiftGodotKit, others perhaps only in the context of the editor.

## Motivation

The intention is to allow a Godot project to have a gdextension file that just looks like this: 

```
[configuration]
entry_symbol = "swift_entry_point"
compatibility_minimum = 4.2

[libraries]
macos.debug = "MyExtension"

[dependencies]
macos.debug = {"SwiftGodot" : ""}
```

and to have the editor or libgodot resolve the precise name and/or location of the library at runtime.

## Other Comments

You probably won't want to take this PR as it stands, and arguably it should be submitted upstream to Godot, but I figured I'd make a PR for discussion.