### PR TITLE
Add Windows shared library support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -308,7 +308,6 @@ if env["library_type"] == "static_library":
     env.Append(CPPDEFINES=["LIBGODOT_ENABLED"])
 elif env["library_type"] == "shared_library":
     env.Append(CPPDEFINES=["LIBGODOT_ENABLED"])
-    env.Append(CCFLAGS=["-fPIC"])
     env.Append(STATIC_AND_SHARED_OBJECTS_ARE_THE_SAME=True)
 else:
     env.__class__.add_program = methods.add_program
@@ -827,6 +826,11 @@ if env["disable_exceptions"]:
         env.Append(CXXFLAGS=["-fno-exceptions"])
 elif env.msvc:
     env.Append(CXXFLAGS=["/EHsc"])
+
+# Add -fPIC for shared library builds on non-MSVC compilers.
+# MSVC generates position-independent code by default.
+if env["library_type"] == "shared_library" and not env.msvc:
+    env.Append(CCFLAGS=["-fPIC"])
 
 # Configure compiler warnings
 if env.msvc and not methods.using_clang(env):  # MSVC

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -26,6 +26,7 @@ common_win = [
     "rendering_context_driver_vulkan_windows.cpp",
     "drop_target_windows.cpp",
     "rendering_native_surface_windows.cpp",
+    "libgodot_windows.cpp",
 ]
 
 if env.msvc:
@@ -71,8 +72,8 @@ else:
 if env.msvc:
     env.Depends(prog, "godot.natvis")
 
-# Build console wrapper app.
-if env["windows_subsystem"] == "gui":
+# Build console wrapper app (only for executable builds).
+if env["windows_subsystem"] == "gui" and env["library_type"] == "executable":
     env_wrap = env.Clone()
     res_wrap_file = "godot_res_wrap.rc"
     res_wrap_target = "godot_res_wrap" + env["OBJSUFFIX"]
@@ -135,7 +136,7 @@ if env["d3d12"]:
 if not os.getenv("VCINSTALLDIR"):
     if env["debug_symbols"]:
         env.AddPostAction(prog, env.Run(platform_windows_builders.make_debug_mingw))
-        if env["windows_subsystem"] == "gui":
+        if env["windows_subsystem"] == "gui" and env["library_type"] == "executable":
             env.AddPostAction(prog_wrap, env.Run(platform_windows_builders.make_debug_mingw))
 
 env.platform_sources += sources

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -32,6 +32,7 @@
 
 #include "drop_target_windows.h"
 #include "os_windows.h"
+#include "rendering_native_surface_windows.h"
 #include "wgl_detect_version.h"
 
 #include "core/config/project_settings.h"
@@ -6278,7 +6279,6 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 			if (rendering_context->window_create(id, windows_surface) != OK) {
 				ERR_PRINT(vformat("Failed to create %s window.", rendering_driver));
 				memdelete(rendering_context);
-				memdelete(windows_surface);
 				rendering_context = nullptr;
 				windows.erase(id);
 				return INVALID_WINDOW_ID;
@@ -6287,7 +6287,6 @@ DisplayServer::WindowID DisplayServerWindows::_create_window(WindowMode p_mode, 
 			rendering_context->window_set_size(id, real_client_rect.right - real_client_rect.left, real_client_rect.bottom - real_client_rect.top);
 			rendering_context->window_set_vsync_mode(id, p_vsync_mode);
 			wd.context_created = true;
-			memdelete(windows_surface);
 		}
 #endif
 

--- a/platform/windows/libgodot_windows.cpp
+++ b/platform/windows/libgodot_windows.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  rendering_native_surface_windows.cpp                                  */
+/*  libgodot_windows.cpp                                                  */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,48 +28,43 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "rendering_native_surface_windows.h"
+#include "core/extension/libgodot.h"
 
-#if defined(VULKAN_ENABLED)
-#include "rendering_context_driver_vulkan_windows.h"
-#endif
-#if defined(D3D12_ENABLED)
-#include "drivers/d3d12/rendering_context_driver_d3d12.h"
-#endif
+#include "core/extension/godot_instance.h"
+#include "main/main.h"
 
-void RenderingNativeSurfaceWindows::_bind_methods() {
-	ClassDB::bind_static_method("RenderingNativeSurfaceWindows", D_METHOD("create", "hwnd", "instance"), &RenderingNativeSurfaceWindows::create_api);
-}
+#include "os_windows.h"
 
-Ref<RenderingNativeSurfaceWindows> RenderingNativeSurfaceWindows::create_api(GDExtensionConstPtr<const void> p_window, GDExtensionConstPtr<const void> p_instance) {
-	return RenderingNativeSurfaceWindows::create((HWND)p_window.operator const void *(), (HINSTANCE)p_instance.operator const void *());
-}
+static OS_Windows *os = nullptr;
 
-Ref<RenderingNativeSurfaceWindows> RenderingNativeSurfaceWindows::create(HWND p_window, HINSTANCE p_instance) {
-	Ref<RenderingNativeSurfaceWindows> result = memnew(RenderingNativeSurfaceWindows);
-	result->set_window(p_window);
-	result->set_instance(p_instance);
-	return result;
-}
+static GodotInstance *instance = nullptr;
 
-RenderingContextDriver *RenderingNativeSurfaceWindows::create_rendering_context(const String &p_driver_name) {
-#if defined(VULKAN_ENABLED)
-	if (p_driver_name == "vulkan") {
-		return memnew(RenderingContextDriverVulkanWindows);
+LIBGODOT_API GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func, InvokeCallbackFunction p_async_func, ExecutorData p_async_data, InvokeCallbackFunction p_sync_func, ExecutorData p_sync_data) {
+	ERR_FAIL_COND_V_MSG(instance != nullptr, nullptr, "Only one Godot Instance may be created.");
+
+	os = new OS_Windows(nullptr);
+
+	Error err = Main::setup(p_argv[0], p_argc - 1, &p_argv[1], false);
+	if (err != OK) {
+		return nullptr;
 	}
-#endif
-#if defined(D3D12_ENABLED)
-	if (p_driver_name == "d3d12") {
-		return memnew(RenderingContextDriverD3D12);
+
+	instance = memnew(GodotInstance);
+	if (!instance->initialize(p_init_func)) {
+		memdelete(instance);
+		instance = nullptr;
+		return nullptr;
 	}
-#endif
-	return nullptr;
+
+	return (GDExtensionObjectPtr)instance;
 }
 
-RenderingNativeSurfaceWindows::RenderingNativeSurfaceWindows() {
-	// Does nothing.
-}
-
-RenderingNativeSurfaceWindows::~RenderingNativeSurfaceWindows() {
-	// Does nothing.
+LIBGODOT_API void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance) {
+	GodotInstance *godot_instance = (GodotInstance *)p_godot_instance;
+	if (instance == godot_instance) {
+		godot_instance->stop();
+		memdelete(godot_instance);
+		instance = nullptr;
+		Main::cleanup();
+	}
 }

--- a/platform/windows/rendering_context_driver_vulkan_windows.cpp
+++ b/platform/windows/rendering_context_driver_vulkan_windows.cpp
@@ -33,8 +33,10 @@
 #include "core/os/os.h"
 
 #include "rendering_context_driver_vulkan_windows.h"
+#include "rendering_native_surface_windows.h"
 
 #include "drivers/vulkan/godot_vulkan.h"
+#include "drivers/vulkan/rendering_native_surface_vulkan.h"
 
 const char *RenderingContextDriverVulkanWindows::_get_platform_surface_extension() const {
 	return VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
@@ -64,7 +66,7 @@ RenderingContextDriver::SurfaceID RenderingContextDriverVulkanWindows::surface_c
 	VkResult err = vkCreateWin32SurfaceKHR(instance_get(), &create_info, get_allocation_callbacks(VK_OBJECT_TYPE_SURFACE_KHR), &vk_surface);
 	ERR_FAIL_COND_V(err != VK_SUCCESS, SurfaceID());
 
-	Ref<RenderingNativeSurfaceVulkan> vulkan_surface = RenderingContextDriverVulkan::create(vk_surface);
+	Ref<RenderingNativeSurfaceVulkan> vulkan_surface = RenderingNativeSurfaceVulkan::create(vk_surface);
 	RenderingContextDriver::SurfaceID result = RenderingContextDriverVulkan::surface_create(vulkan_surface);
 	return result;
 }

--- a/platform/windows/rendering_native_surface_windows.h
+++ b/platform/windows/rendering_native_surface_windows.h
@@ -60,6 +60,9 @@ public:
 		return instance;
 	}
 
+	void set_window(HWND p_window) { window = p_window; }
+	void set_instance(HINSTANCE p_instance) { instance = p_instance; }
+
 	RenderingContextDriver *create_rendering_context(const String &p_driver_name) override;
 
 	RenderingNativeSurfaceWindows();


### PR DESCRIPTION
- Add libgodot_windows.cpp with libgodot_create/destroy_godot_instance
- Move -fPIC flag to only apply on non-MSVC compilers
- Remove memdelete() on Ref<>-managed surfaces (auto-released)
- Fix RenderingNativeSurfaceWindows method names and add setters
- Skip console wrapper build for library builds
- Add missing includes for rendering context drivers